### PR TITLE
Nova funcionalidade

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -70,7 +70,13 @@ else
 
 	# Remove os acentos do arquivo
 	acentos='y/áÁàÀãÃâÂéÉêÊíÍóÓõÕôÔúÚçÇ/aAaAaAaAeEeEiIoOoOoOuUcC/'
-	$(sed $acentos <$code.c> $code.tmp; mv $code.tmp $code.c)
+	$(sed $acentos <$code.c> $code.tmp)
+	
+	# Salva somente se os arquivos forem diferentes
+	$(cmp "$code.c" "$code.tmp" || mv "$code.tmp" "$code.c")
+	if [ -f $code.tmp ]; then
+	    $(rm $code.tmp)
+	fi
 
 	#Compila
 	echo -e "$yellow Compilando codigo $normal"

--- a/test.sh
+++ b/test.sh
@@ -73,7 +73,7 @@ else
 	$(sed $acentos <$code.c> $code.tmp)
 	
 	# Salva somente se os arquivos forem diferentes
-	$(cmp "$code.c" "$code.tmp" || mv "$code.tmp" "$code.c")
+	$(cmp $code.c $code.tmp || mv $code.tmp $code.c)
 	if [ -f $code.tmp ]; then
 	    $(rm $code.tmp)
 	fi

--- a/test.sh
+++ b/test.sh
@@ -7,9 +7,11 @@
 #	Alterar o nome da turma
 #
 #	Modo de uso:
-#	./test.sh nome do programa
+#	./test.sh nome_do_programa
+#       ./test.sh nome_do_programa teste_a_ser_executado
 
 code="$1"
+teste="$2"
 turma="mc102wy"
 i=1;
 
@@ -23,88 +25,126 @@ yellow="\033[33m"
 normal="\033[0m"
 bold="\033[1m"
 
+# $1 : codigo a ser executado
+# $2 : arquivo teste
+# $3 : numero do teste
+function executaTeste {
+    # Itera pelos testes
+    printf "$yellow R $normal Teste $bold[%02d]$normal... " $((10#$3))
+
+    # Cria a saida de acordo com a entrada
+    $(./$1 < $2.in > $2.out)
+
+    # Compara com o resultado esperado e
+    # diz se o programa passou ou nao
+
+    $(diff $2.out $2.res > ./.thediff 2>&1)
+
+    if [ $? != 0 ]
+    then
+	echo -e "$red FAIL\n $normal $(cat ./.thediff)"
+    else
+	echo -e "$green OK $normal"
+    fi
+
+    # Remove o arquivo de saida
+    $(rm $2.out)
+}
+
 #Verifica se o numero de parametros esta correto
-# o unico parametro que o programa deve receber eh o nome do programa
-if [ ! $# -eq 1 ]; then
-    echo "Numero de parametros incorretos, apenas o nome do laborarior (ex lab00x) eh necessario"
+if [ $# -gt 2 ]; then
+    echo "Numero de parametros incorretos"
+    echo "O nome do laborarior (ex lab00x), eh obrigatorio"
+    echo "O numero do teste, eh opcional"
 else
-    # Retira a extensao do nome do arquivo caso o usuario tenha colocado
-    # o codigo C ao inves do nome do programa
-    code="${code%.*}"
-
-
-    # Remove os acentos do arquivo
-    acentos='y/áÁàÀãÃâÂéÉêÊíÍóÓõÕôÔúÚçÇ/aAaAaAaAeEeEiIoOoOoOuUcC/'
-    $(sed $acentos <$code.c> $code.tmp; mv $code.tmp $code.c)
-
-    #Compila
-    echo -e "$yellow Compilando codigo $normal"
-    $(gcc -ansi $code.c -o $code -lm)
-
-    #Caso a compilacao tenha dado erro
-    if [ ! $? -eq 0 ]; then
+    # Verifica se o nome do laboratorio foi passado
+    if [ -z $1 ]; then
 	#Sair do programa
 	echo -e "$red ERROR  $normal"
 	exit 1
-
     else
-	#Caso contrario continuar com a execucao dos testes
+	# Retira a extensao do nome do arquivo caso o usuario tenha colocado
+	# o codigo C ao inves do nome do programa
+	code="${code%.*}"
 
-	# Se o diretorio nao existe, baixe os arquivos e crie o diretorio
-	if ( [ -d aux ] ); then
-	    echo -e "$yellow W $normal Usando diretorio $yellow[aux]$normal local"
+
+	# Remove os acentos do arquivo
+	acentos='y/áÁàÀãÃâÂéÉêÊíÍóÓõÕôÔúÚçÇ/aAaAaAaAeEeEiIoOoOoOuUcC/'
+	$(sed $acentos <$code.c> $code.tmp; mv $code.tmp $code.c)
+
+	#Compila
+	echo -e "$yellow Compilando codigo $normal"
+	$(gcc -ansi $code.c -o $code -lm)
+
+	#Caso a compilacao tenha dado erro
+	if [ ! $? -eq 0 ]; then
+	    #Sair do programa
+	    echo -e "$red ERROR  $normal"
+	    exit 1
+
 	else
-	    echo -e "$yellow W $normal Baixando testes..."
-	    read -p $'\e[33m Q \e[0m Numero do lab (ex. 00x): ' nlab
+	    #Caso contrario continuar com a execucao dos testes
 
-	    # Cria o diretorio e baixa o zip
-	    $(mkdir aux)
-	    $(curl -silent -LOk https://susy.ic.unicamp.br:9999/$turma/$nlab/aux/testes.zip)
-
-	    echo -e "$yellow W $normal Descompactando arquivos..."
-
-	    # Descompacta os arquivos e deleta o zip
-	    $(unzip -q testes.zip -d aux > /dev/null 2>&1)
-	    $(rm testes.zip)
-
-	fi
-
-	# Para cada arquivo em aux com final .in
-
-	echo -e "$red I $normal Rodando testes"
-
-	for filename in $(pwd)/aux/*.in; do
-
-	    # Retira a extensao do nome do arquivo
-	    file="${filename%.*}"
-
-	    # Itera pelos testes
-	    printf "$yellow R $normal Teste $bold[%02d]$normal... " $i
-
-	    # Cria a saida de acordo com a entrada
-	    $(./$code < $file.in > $file.out)
-
-	    # Compara com o resultado esperado e
-	    # diz se o programa passou ou nao
-
-	    $(diff $file.out $file.res > ./.thediff 2>&1)
-
-	    if [ $? != 0 ]
-	    then
-		echo -e "$red FAIL\n $normal $(cat ./.thediff)"
+	    # Se o diretorio nao existe, baixe os arquivos e crie o diretorio
+	    if ( [ -d aux ] ); then
+		echo -e "$yellow W $normal Usando diretorio $yellow[aux]$normal local"
 	    else
-		echo -e "$green OK $normal"
+		echo -e "$yellow W $normal Baixando testes..."
+		read -p $'\e[33m Q \e[0m Numero do lab (ex. 00x): ' nlab
+
+		# Cria o diretorio e baixa o zip
+		$(mkdir aux)
+		$(curl -silent -LOk https://susy.ic.unicamp.br:9999/$turma/$nlab/aux/testes.zip)
+
+		echo -e "$yellow W $normal Descompactando arquivos..."
+
+		# Descompacta os arquivos e deleta o zip
+		$(unzip -q testes.zip -d aux > /dev/null 2>&1)
+		$(rm testes.zip)
+
 	    fi
 
-	    # Remove o arquivo de saida
-	    $(rm $file.out)
+	    
+	    echo -e "$red I $normal Rodando testes"
+	    if [ ! -z $2 ]; then
+		# o numero do teste a ser executado foi passado
 
-	    # i += 1
-	    i=`expr $i + 1`
-	done
+		# Remove os 0's a esquerda do numero, para que 001 e 01 sejam iguais a 1
+		teste=$(echo $teste | sed 's/^0*//')
+		
+		if [ $teste -gt 10 ]; then
+		    #Sair do programa
+		    echo -e "$red ERROR $teste nao eh um teste valido  $normal"
+		    exit 1
+		fi
+		
+		#formata o parametro para ter formato (00)
+		while [[ $(echo -n ${teste} | wc -c) -lt 2 ]] ; do
+		    teste="0${teste}"
+		done
+		
+		filename=$(pwd)/aux/arq$teste.in;
+		file="${filename%.*}"
+		#Executa funcao
+		executaTeste $code $file $teste		
+	    else
+		# Para cada arquivo em aux com final .in
+
+		for filename in $(pwd)/aux/*.in; do
+
+		    # Retira a extensao do nome do arquivo
+		    file="${filename%.*}"
+
+		    # Executa funcao
+		    executaTeste $code $file $i
+		    
+		    # i += 1
+		    i=`expr $i + 1`
+		done
+	    fi
+	fi
+
+	# Remove o arquivo temporario
+	$(rm ./.thediff)
     fi
-
-    # Remove o arquivo temporario
-    $(rm ./.thediff)
-
 fi


### PR DESCRIPTION
Capacidade de escolher o teste a ser executado. 
Com a finalidade de despoluir o terminal ao printar informacoes de debug

O numero de teste pode ser escrito na forma (1) ou (01) ou ainda (001) que serao considerados o teste (01).
Caso o usuario tente executar um teste maior que (10), o programa dira que nao existe e sairá d script

Caso apenas o nome do codigo seja passado como parametro, o comportamento continua o mesmo, executando todos os testes

Arrumado a funcionalidade de retirar acentos do codigo: Salva a retirada dos acentos caso haja algum acento a ser retirado do codigo.
